### PR TITLE
Add pre-save page for song release

### DIFF
--- a/src/pages/pre-save.astro
+++ b/src/pages/pre-save.astro
@@ -1,0 +1,75 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+const title = "New Release - Pre-save";
+---
+<BaseLayout title={title}>
+  <div class="presave-container">
+    <div class="player-card">
+      <img src="https://placekitten.com/400/400" alt="Album Art" class="album-art" />
+      <div class="info">
+        <h2>My New Single</h2>
+        <p>Artist Name</p>
+      </div>
+      <div class="links">
+        <a class="btn bandcamp" href="#" target="_blank" rel="noopener">Pre-save on Bandcamp</a>
+        <a class="btn spotify" href="#" target="_blank" rel="noopener">Pre-save on Spotify</a>
+        <a class="btn soundcloud" href="#" target="_blank" rel="noopener">Pre-save on SoundCloud</a>
+      </div>
+    </div>
+  </div>
+</BaseLayout>
+<style>
+  .presave-container {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #1db954, #1e3264);
+    padding: 2rem;
+  }
+  .player-card {
+    width: 100%;
+    max-width: 400px;
+    background: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 2rem;
+    text-align: center;
+    color: #fff;
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  }
+  .album-art {
+    width: 100%;
+    border-radius: 15px;
+    margin-bottom: 1rem;
+  }
+  .info h2 {
+    margin: 0.5rem 0 0.25rem;
+    font-size: 1.5rem;
+  }
+  .info p {
+    margin: 0;
+    font-size: 1rem;
+    opacity: 0.8;
+  }
+  .links {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem;
+    border-radius: 12px;
+    font-weight: 600;
+    color: #fff;
+    text-decoration: none;
+  }
+  .btn.bandcamp { background: #629aa9; }
+  .btn.spotify { background: #1db954; }
+  .btn.soundcloud { background: #ff7700; }
+  .btn:hover { opacity: 0.9; }
+</style>


### PR DESCRIPTION
## Summary
- create `pre-save.astro` page styled like a mobile media player with gradient background and translucent card
- include pre-save buttons linking to Bandcamp, Spotify, and SoundCloud

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba9f1865308328b5c475ec7b33dd3e